### PR TITLE
add pytest-raisin as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "mypy",
   "pytest-cov",
   "pytest",
+  "pytest-raisin",
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/pytest_example --cov=tests {args}"


### PR DESCRIPTION
There is a plugin required for using `pytest.raises` with an exception _instance_